### PR TITLE
Changes done to avoid too long tar_path name, error encountered :  ta…

### DIFF
--- a/containerscan.py
+++ b/containerscan.py
@@ -224,7 +224,7 @@ class Scanner():
         If encountering errors at this step, ensure docker login credentials are
         correct, and the user has appropriate permissions.
         """
-
+        image_name = image_name.split('/')[-1]
         tar_path = '%s/%s.tar' % (self.tempDirectory,
             image_name.replace('/','.').replace(':','.').replace('@','.'))
         tarball = open(tar_path, 'w')


### PR DESCRIPTION
…rball = open(tar_path, 'w') OSError: [Errno 36] File name too long